### PR TITLE
Change spell check colors to be close to the Vim default

### DIFF
--- a/colors/default-light.vim
+++ b/colors/default-light.vim
@@ -12,8 +12,8 @@ highlight Title          ctermfg=5
 highlight WarningMsg     ctermfg=1
 highlight WildMenu       ctermfg=0 ctermbg=11
 highlight Conceal        ctermfg=7 ctermbg=7
-highlight SpellBad       ctermbg=2
-highlight SpellRare      ctermbg=5
+highlight SpellBad       ctermbg=9
+highlight SpellRare      ctermbg=13
 highlight SpellLocal     ctermbg=14
 highlight PmenuSbar      ctermbg=8
 highlight PmenuThumb     ctermbg=0


### PR DESCRIPTION
Particularly change the SpellBad highlighting group from red to green.

In my color scheme those colors look very close to Vim's default colors. I used the following command for testing:

```
:echohl SpellBad|echo "bad"|echohl SpellRare|echo "rare"|echohl SpellLocal|echo "local"
```

| Before | After | Vim default |
| --- | --- | --- |
| ![image](https://user-images.githubusercontent.com/8438790/103161995-8b4e0e80-47ea-11eb-818b-0456ab324751.png) | ![image](https://user-images.githubusercontent.com/8438790/103161988-7a050200-47ea-11eb-808f-d420a03c7ecc.png) | ![image](https://user-images.githubusercontent.com/8438790/103161981-622d7e00-47ea-11eb-8175-3e6ea9a26e07.png) |