### PR TITLE
Grim: A monochrome version of Dim

### DIFF
--- a/colors/grim.vim
+++ b/colors/grim.vim
@@ -1,0 +1,23 @@
+exec "source " . expand('<sfile>:p:h') . "/dim.vim"
+
+let colors_name = "grim"
+
+if &background == "light"
+  highlight Constant       ctermfg=8
+  highlight Identifier     ctermfg=0
+  highlight PreProc        ctermfg=0 cterm=bold
+  highlight Special        ctermfg=0
+  highlight Statement      ctermfg=0 cterm=bold
+  highlight Title          ctermfg=0 cterm=bold
+  highlight Type           ctermfg=0
+  highlight Underlined     cterm=underline ctermfg=0
+else
+  highlight Constant       ctermfg=7
+  highlight Identifier     ctermfg=15
+  highlight PreProc        ctermfg=15 cterm=bold
+  highlight Special        ctermfg=15
+  highlight Statement      ctermfg=15 cterm=bold
+  highlight Title          ctermfg=15 cterm=bold
+  highlight Type           ctermfg=15
+  highlight Underlined     cterm=underline ctermfg=15
+end


### PR DESCRIPTION
Grim is a monochrome version of Dim, that uses the grayscale ANSI Colors (Back/0, Bright black/8, White/7, Bright white/15) for syntax “highlighting”. It uses bold type for `PreProc`, `Statement` and `Title` groups.

Outside of those changes, Grim falls back do Dim’s colors. This means search results and diffs are still highlighted, for example. Since Grim directly depends on Dim, I’d like to bundle them together.

![Grim on a light background](https://user-images.githubusercontent.com/43621/105404713-9306a480-5c2a-11eb-9f96-6e6b1f78ed14.jpeg)
![Grim on a dark background](https://user-images.githubusercontent.com/43621/105404721-9568fe80-5c2a-11eb-9e0e-08d047e69dcf.jpeg)

I’ve been using Grim myself for a couple of weeks now. I’m not expecting Grim to be very popular, but still wanted to see if anyone would like to take it for a spin and show me what it looks like in their setup before I merge this.