### PR TITLE
Set notermguicolors to support neovim >= 0.10

### DIFF
--- a/colors/dim.vim
+++ b/colors/dim.vim
@@ -4,6 +4,8 @@ if exists("syntax_on")
   syntax reset
 endif
 
+set notermguicolors
+
 exec "source " . expand('<sfile>:p:h') . "/default-light.vim"
 
 let colors_name = "dim"


### PR DESCRIPTION
Since version 0.10.0[1], neovim enables termguicolors when it determines it's in a 24-bit color terminal. When termguicolors is turned on, Vim uses the gui colors instead of the cterm versions.

When Dim is loaded, it clears all highlights, and only sets cterm colors. As long as termguicolors is disabled, this works for all terminals. However, if termguicolors is enabled, Vim tries to use the gui colors, which were cleared by Dim, causing unhighlighted buffers.

This patch makes sure termguicolors is disabled whenever Dim is loaded to make sure Vim falls back to cterm colors.

This could cause issues when loading Dim and then switching to another theme where termguicolors is expected to be enabled, but there doesn't seem to be a way to only disable termguicolors while Dim is used as the color scheme.

[1]: https://neovim.io/doc/user/news-0.10.html

Closes #12.